### PR TITLE
feat: maci-signup-flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,6 @@ NEXT_PUBLIC_EAS_SCHEMA_REGISTRY_ADDRESS=0x42000000000000000000000000000000000000
 # You can register schemas by running the script: npm run eas:registerSchemas
 # Do this if the schemas doesn't exist on the network you're using.
 WALLET_PRIVATE_KEY=""
+
+# Deploy your own maci address, with the schema mentioned above being passed inside
+NEXT_PUBLIC_MACI_ADDRESS=

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export const config = {
   admins: (process.env.NEXT_PUBLIC_ADMIN_ADDRESSES ?? "").split(","),
   network:
     wagmiChains[process.env.NEXT_PUBLIC_CHAIN_NAME as keyof typeof wagmiChains],
+  maciAddress: process.env.NEXT_PUBLIC_MACI_ADDRESS,
 };
 
 export const theme = {

--- a/src/env.js
+++ b/src/env.js
@@ -106,6 +106,8 @@ export const env = createEnv({
     NEXT_PUBLIC_ALCHEMY_ID: z.string().optional(),
 
     NEXT_PUBLIC_SKIP_APPROVED_VOTER_CHECK: z.string(),
+
+    NEXT_PUBLIC_MACI_ADDRESS: z.string(),
   },
 
   /**
@@ -157,6 +159,8 @@ export const env = createEnv({
     NEXT_PUBLIC_METADATA_SCHEMA: process.env.NEXT_PUBLIC_METADATA_SCHEMA,
 
     NEXT_PUBLIC_ROUND_ID: process.env.NEXT_PUBLIC_ROUND_ID,
+
+    NEXT_PUBLIC_MACI_ADDRESS: process.env.NEXT_PUBLIC_MACI_ADDRESS,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/hooks/useMaci.ts
+++ b/src/hooks/useMaci.ts
@@ -1,0 +1,33 @@
+import { signup } from "maci-cli/sdk";
+import { type Signer } from "ethers";
+
+import { api } from "~/utils/api";
+import { config } from "~/config";
+
+export function useMaci() {
+    const userStateIndex = localStorage.getItem("maci-userstate-index");
+
+    async function signUpMaci(attestation: string, pubKey: string, signer: Signer) {
+
+        // 1. signup on maci
+        const stateIndex = await signup({
+            maciPubKey: pubKey,
+            maciAddress: config.maciAddress!,
+            sgDataArg: attestation,
+            signer
+        }); // --> not supported since it's using hardhat, but if we wanna use ethers instead, how? or just throw this function to server?
+    
+        // 2. save the state index to local storage
+        localStorage.setItem("userstate-index", stateIndex.toString());
+    }
+
+    return {
+        userStateIndex,
+        isMaciSignedUp: userStateIndex !== null,
+        signUpMaci
+    }
+}
+
+export function useApprovedAttestation(address: string) {
+    return api.voters.approvedAttestation.useQuery({ address });
+} 

--- a/src/server/api/routers/voters.ts
+++ b/src/server/api/routers/voters.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import {
   fetchAttestations,
+  fetchApprovedVoterAttestation,
   createDataFilter,
   fetchApprovedVoter,
 } from "~/utils/fetchAttestations";
@@ -18,6 +19,11 @@ export const votersRouter = createTRPCRouter({
     .input(z.object({ address: z.string() }))
     .query(async ({ input }) => {
       return fetchApprovedVoter(input.address);
+    }),
+  approvedAttestation: publicProcedure
+    .input(z.object({ address: z.string() }))
+    .query(async ({ input }) => {
+      return fetchApprovedVoterAttestation(input.address);
     }),
   list: publicProcedure.input(FilterSchema).query(async ({}) => {
     return fetchAttestations([eas.schemas.approval], {

--- a/src/utils/fetchAttestations.ts
+++ b/src/utils/fetchAttestations.ts
@@ -80,6 +80,15 @@ export async function fetchAttestations(
   }).then((r) => r.data?.attestations.map(parseAttestation));
 }
 
+export async function fetchApprovedVoterAttestation(address: string) {
+  return fetchAttestations([eas.schemas.approval], {
+    where: {
+      recipient: { equals: address },
+      ...createDataFilter("type", "bytes32", "voter"),
+    },
+  }).then((attestations) => attestations[0]);
+}
+
 export async function fetchApprovedVoter(address: string) {
   if (config.skipApprovedVoterCheck) return true;
   return fetchAttestations([eas.schemas.approval], {


### PR DESCRIPTION
- [x] adding `useMaci` hook
- [x] adding button to signup to maci in `ConnectButton.tsx`
- [x] adding `NEXT_PUBLIC_MACI_ADDRESS` in .env.example and update the configs

problems:
```
../maci/node_modules/.pnpm/@nomicfoundation+solidity-analyzer-darwin-x64@0.1.1/node_modules/@nomicfoundation/solidity-analyzer-darwin-x64/solidity-analyzer.darwin-x64.node
Module parse failed: Unexpected character '�' (1:0)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
(Source code omitted for this binary file)

Import trace for requested module:
../maci/node_modules/.pnpm/@nomicfoundation+solidity-analyzer-darwin-x64@0.1.1/node_modules/@nomicfoundation/solidity-analyzer-darwin-x64/solidity-analyzer.darwin-x64.node
../maci/node_modules/.pnpm/@nomicfoundation+solidity-analyzer@0.1.1/node_modules/@nomicfoundation/solidity-analyzer/index.js
../maci/node_modules/.pnpm/hardhat@2.19.5_ts-node@10.9.2_typescript@5.3.3/node_modules/hardhat/internal/solidity/parse.js
../maci/node_modules/.pnpm/hardhat@2.19.5_ts-node@10.9.2_typescript@5.3.3/node_modules/hardhat/builtin-tasks/compile.js
../maci/node_modules/.pnpm/hardhat@2.19.5_ts-node@10.9.2_typescript@5.3.3/node_modules/hardhat/internal/core/tasks/builtin-tasks.js
../maci/node_modules/.pnpm/hardhat@2.19.5_ts-node@10.9.2_typescript@5.3.3/node_modules/hardhat/internal/core/config/config-loading.js
../maci/node_modules/.pnpm/hardhat@2.19.5_ts-node@10.9.2_typescript@5.3.3/node_modules/hardhat/internal/lib/hardhat-lib.js
../maci/contracts/build/ts/deploy.js
../maci/contracts/build/ts/index.js
../maci/cli/build/ts/commands/airdrop.js
../maci/cli/build/ts/commands/index.js
../maci/cli/build/ts/index.js
./src/hooks/useMaci.ts
./src/components/ConnectButton.tsx
./src/components/Header.tsx
./src/layouts/DefaultLayout.tsx
./src/pages/projects/index.tsx
```

Not sure what's the main reason here. I thought it was caused by importing hardhat modules, but I checked my past repos, they still work well even with hardhat dependencies 🤔

We also tried to remove calling `defaultSigner()` and `defaultNetwork()` (linking local package), but it still not works.