### PR TITLE
chore: add error handler for signup

### DIFF
--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -6,6 +6,7 @@ import { FaListCheck } from "react-icons/fa6";
 
 import { ConnectButton as RainbowConnectButton } from "@rainbow-me/rainbowkit";
 import { createBreakpoint } from "react-use";
+import { toast } from "sonner";
 
 import { Button } from "./ui/Button";
 import { Chip } from "./ui/Chip";
@@ -93,7 +94,11 @@ const ConnectedDetails = ({
 }) => {
   const { data: ballot } = useBallot();
   const ballotSize = (ballot?.votes ?? []).length;
-  const { isRegistered, isEligibleToVote, onSignup } = useMaciSignup();
+  const { isLoading, isRegistered, isEligibleToVote, onSignup } = useMaciSignup(
+    {
+      onError: () => toast.error("Signup error"),
+    },
+  );
 
   const { showBallot } = useLayoutOptions();
   return (
@@ -103,7 +108,7 @@ const ConnectedDetails = ({
 
         {isEligibleToVote && !isRegistered && (
           <SignupButton
-            loading={isRegistered === undefined}
+            loading={isRegistered === undefined || isLoading}
             onClick={onSignup}
           />
         )}

--- a/src/env.js
+++ b/src/env.js
@@ -45,6 +45,7 @@ export const env = createEnv({
       "linea",
       "sepolia",
       "baseGoerli",
+      "localhost",
     ]),
     NEXT_PUBLIC_SIGN_STATEMENT: z.string().optional(),
 

--- a/src/features/ballot/components/BallotOverview.tsx
+++ b/src/features/ballot/components/BallotOverview.tsx
@@ -23,11 +23,16 @@ import { getAppState } from "~/utils/state";
 import dynamic from "next/dynamic";
 import { useMaciSignup } from "~/hooks/useMaciSignup";
 import { useMaciVote } from "~/hooks/useMaciVote";
+import { toast } from "sonner";
 
 function BallotOverview() {
   const router = useRouter();
 
-  const { isRegistered, isEligibleToVote, onSignup } = useMaciSignup();
+  const { isLoading, isRegistered, isEligibleToVote, onSignup } = useMaciSignup(
+    {
+      onError: () => toast.error("Signup error"),
+    },
+  );
   const { data: ballot } = useBallot();
 
   const sum = sumBallot(ballot?.votes);
@@ -108,7 +113,11 @@ function BallotOverview() {
           </div>
         </div>
       </BallotSection>
-      {!isEligibleToVote ? null : !isRegistered ? (
+      {!isEligibleToVote ? null : isLoading ? (
+        <Button className="w-full" variant="primary" disabled>
+          Loading...
+        </Button>
+      ) : !isRegistered ? (
         <Button className="w-full" variant="primary" onClick={onSignup}>
           Signup
         </Button>

--- a/src/features/lists/components/ListEditDistribution.tsx
+++ b/src/features/lists/components/ListEditDistribution.tsx
@@ -14,6 +14,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useFormContext } from "react-hook-form";
+import { toast } from "sonner";
 
 import { Button, IconButton } from "~/components/ui/Button";
 import { Dialog } from "~/components/ui/Dialog";
@@ -45,7 +46,9 @@ export const ListEditDistribution = ({
   const [isOpen, setOpen] = useState(false);
   const { data: ballot } = useBallot();
   const add = useAddToBallot();
-  const { isRegistered, isEligibleToVote, onSignup } = useMaciSignup();
+  const { isRegistered, isEligibleToVote, onSignup } = useMaciSignup({
+    onError: () => toast.error("Signup error"),
+  });
 
   // What list projects are already in the ballot?
   function itemsInBallot(votes?: Vote[]) {

--- a/src/features/projects/components/AddToBallot.tsx
+++ b/src/features/projects/components/AddToBallot.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { useAccount } from "wagmi";
 import { useFormContext } from "react-hook-form";
 import { Check } from "lucide-react";
+import { toast } from "sonner";
 
 import { Alert } from "~/components/ui/Alert";
 import { Button, IconButton } from "~/components/ui/Button";
@@ -30,7 +31,11 @@ export const ProjectAddToBallot = ({ id, name }: Props) => {
   const add = useAddToBallot();
   const remove = useRemoveFromBallot();
   const { data: ballot } = useBallot();
-  const { isRegistered, isEligibleToVote, onSignup } = useMaciSignup();
+  const { isLoading, isRegistered, isEligibleToVote, onSignup } = useMaciSignup(
+    {
+      onError: () => toast.error("Signup error"),
+    },
+  );
 
   const inBallot = ballotContains(id!, ballot);
   const allocations = ballot?.votes ?? [];
@@ -48,7 +53,11 @@ export const ProjectAddToBallot = ({ id, name }: Props) => {
         </Alert>
       )}
 
-      {!isEligibleToVote ? null : !isRegistered ? (
+      {!isEligibleToVote ? null : isLoading ? (
+        <Button className="w-full md:w-auto" variant="primary" disabled>
+          Loading...
+        </Button>
+      ) : !isRegistered ? (
         <Button
           className="w-full md:w-auto"
           variant="primary"

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -51,6 +51,11 @@ function createWagmiConfig() {
     wagmiChains.mainnet,
   ];
 
+  if (process.env.NEXT_PUBLIC_CHAIN_NAME === "localhost") {
+    wagmiChains.localhost.id = 31337;
+    activeChains.push(wagmiChains.localhost);
+  }
+
   const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_ID!;
   const appName = appConfig.metadata.title;
 

--- a/src/server/api/routers/ballot.ts
+++ b/src/server/api/routers/ballot.ts
@@ -96,7 +96,13 @@ export const ballotRouter = createTRPCRouter({
       const voterId = ctx.session.user.name!;
 
       return ctx.db.ballot.update({
-        where: { voterId_pollId_maci: { voterId, pollId: input.pollId, maci: config.maciAddress! } },
+        where: {
+          voterId_pollId_maci: {
+            voterId,
+            pollId: input.pollId,
+            maci: config.maciAddress!,
+          },
+        },
         data: { publishedAt: null },
       });
     }),
@@ -152,7 +158,13 @@ export const ballotRouter = createTRPCRouter({
       }
 
       return ctx.db.ballot.update({
-        where: { voterId_pollId_maci: { voterId, pollId: input.pollId, maci: config.maciAddress! } },
+        where: {
+          voterId_pollId_maci: {
+            voterId,
+            pollId: input.pollId,
+            maci: config.maciAddress!,
+          },
+        },
         data: { publishedAt: new Date(), signature },
       });
     }),
@@ -176,7 +188,9 @@ async function verifyUnpublishedBallot(
 ) {
   const existing = await ballot.findUnique({
     select: defaultBallotSelect,
-    where: { voterId_pollId_maci: { voterId, pollId, maci: config.maciAddress! } },
+    where: {
+      voterId_pollId_maci: { voterId, pollId, maci: config.maciAddress! },
+    },
   });
 
   // Can only be submitted once

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -19,7 +19,7 @@ export const getAppState = (): AppState => {
   }
 
   if (isAfter(config.registrationEndsAt, now)) return "APPLICATION";
-  if (isAfter(config.reviewEndsAt, now)) return "REVIEWING";``
+  if (isAfter(config.reviewEndsAt, now)) return "REVIEWING";
   if (isAfter(votingEndsAt, now)) return "VOTING";
   if (!pollData?.isStateAqMerged || !tallyData) return "TALLYING";
 


### PR DESCRIPTION
I tried the react-error-boundary package to handle all errors in the project, but it's more complex while dealing with async functions, and since they already run mutations and building onError functions for most of the actions, so I gave up and only deal with the errors happening during the signup.

- [x] add `isLoading` state to useMaciSignup hook
- [x] add `onError` function to onSignup function
- [x] update related UI (mainly `ConnectButton`)