### PR TITLE
feat: modify ballot overview display

### DIFF
--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -62,11 +62,10 @@ export const Layout = ({ children, ...props }: Props) => {
 };
 
 export function LayoutWithBallot(props: Props) {
-  const { address } = useAccount();
   return (
     <Layout
       sidebar="left"
-      sidebarComponent={address && <BallotOverview />}
+      sidebarComponent={<BallotOverview />}
       {...props}
     />
   );


### PR DESCRIPTION
Description:

Currently, if there were projects added to the ballot, but user not on the /ballot page, the main button in BallotOverview would always be No projects added, which is a little bit weird.
The voting due date should be displayed no matter if the user connected their wallet to signup or not.

Also solving issue #69 by not displaying anything if the `appState === "LOADING"`