### PR TITLE
fix: remove duplicate child to clear warning

### DIFF
--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -51,10 +51,6 @@ export const Layout = ({ children, ...props }: Props) => {
           href: "/distribute",
           children: "Distribute",
         },
-        {
-          href: "/info",
-          children: "Info",
-        },
       ],
     );
   }


### PR DESCRIPTION
Clear the warning of "duplicate list child with same key".