### PR TITLE
chore: limit admin to only one person

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,9 +88,9 @@ NEXT_PUBLIC_RESULTS_DATE=2024-01-01T00:00:00.000Z
 # Collect user feedback. Is shown as a link when user has voted
 NEXT_PUBLIC_FEEDBACK_URL=https://github.com/privacy-scaling-explorations/maci-rpgf/issues/new?title=Feedback
 
-# Comma-separated list of addresses that will approve applications and voters
+# address that will approve applications and voters
 # (leaving empty means anyone can do this)
-NEXT_PUBLIC_ADMIN_ADDRESSES=
+NEXT_PUBLIC_ADMIN_ADDRESS=
 
 
 # -----------------

--- a/docs/01_setup.md
+++ b/docs/01_setup.md
@@ -48,7 +48,7 @@ Here, you can also configure who your admins are. These are the users who will a
 
 To create your own round you need to do a few things:
 
-- Update `NEXT_PUBLIC_ADMIN_ADDRESSES` with a comma-separated list of wallet addresses that approve the applications and voters (badgeholders)
+- Update `NEXT_PUBLIC_ADMIN_ADDRESS` a wallet address that approve the applications and voters (badgeholders)
 - Set `NEXT_PUBLIC_ROUND_ID` to a unique identifier that will group the applications and lists you want to list
 - Set `NEXT_PUBLIC_MACI_ADDRESS` - your deployed maci contract
 - Set `NEXT_PUBLIC_MACI_START_BLOCK` - block where your maci contract is deployed (optional)
@@ -64,7 +64,7 @@ You can also configure your own schemas here if you wish to, or deploy the EAS c
 
 As a coordinator you need to deploy a MACI instance and poll.
 
-### Install Maci
+### Install MACI
 
 You can read about the [MACI requirements here](https://maci.pse.dev/docs/installation). To install MACI run the following commands:
 

--- a/docs/02_adding_projects.md
+++ b/docs/02_adding_projects.md
@@ -20,7 +20,7 @@ This will create an Attestation with the Metadata schema and populate the fields
 ## Reviewing and approving applications
 
 - Navigate to https://easy-retro-pgf.vercel.app/applications (replace the domain with your deployment)
-- Make sure you have configured `NEXT_PUBLIC_ADMIN_ADDRESSES` with the address you connect your wallet with
+- Make sure you have configured `NEXT_PUBLIC_ADMIN_ADDRESS` with the address you connect your wallet with
 - You will see a list of submitted applications
 - Press the Review button to open the application
 - Select the applications you want to approve

--- a/docs/03_creating_badgeholders.md
+++ b/docs/03_creating_badgeholders.md
@@ -1,7 +1,7 @@
 # Creating badgeholders
 
 - Navigate to https://easy-retro-pgf.vercel.app/voters (replace the domain with your deployment)
-- Make sure you have configured `NEXT_PUBLIC_ADMIN_ADDRESSES` with the address you connect your wallet with
+- Make sure you have configured `NEXT_PUBLIC_ADMIN_ADDRESS` with the address you connect your wallet with
 - Enter a list of addresses you want to allow to vote (comma-separated)
 - Press Approve button to create attestations for these voters (send transaction to confirm)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,9 +22,7 @@ export const config = {
   ),
   tokenName: process.env.NEXT_PUBLIC_TOKEN_NAME!,
   roundId: process.env.NEXT_PUBLIC_ROUND_ID!,
-  admins: (process.env.NEXT_PUBLIC_ADMIN_ADDRESSES ?? "").split(
-    ",",
-  ) as `0x${string}`[],
+  admin: (process.env.NEXT_PUBLIC_ADMIN_ADDRESS ?? "") as `0x${string}`,
   network:
     wagmiChains[process.env.NEXT_PUBLIC_CHAIN_NAME as keyof typeof wagmiChains],
   maciAddress: process.env.NEXT_PUBLIC_MACI_ADDRESS,

--- a/src/contexts/Maci.tsx
+++ b/src/contexts/Maci.tsx
@@ -53,7 +53,7 @@ export const MaciProvider: React.FC<MaciProviderProps> = ({ children }) => {
     const values = attestations.data?.valueOf() as Attestation[] | undefined;
 
     const attestation = values?.find((attestation) =>
-      config.admins.includes(attestation.attester),
+      config.admin === attestation.attester,
     );
 
     return attestation?.id;

--- a/src/env.js
+++ b/src/env.js
@@ -102,7 +102,7 @@ export const env = createEnv({
       .string()
       .default("https://optimism.easscan.org/graphql"),
 
-    NEXT_PUBLIC_ADMIN_ADDRESSES: z.string().startsWith("0x"),
+    NEXT_PUBLIC_ADMIN_ADDRESS: z.string().startsWith("0x"),
     NEXT_PUBLIC_APPROVAL_SCHEMA: z.string().startsWith("0x"),
     NEXT_PUBLIC_METADATA_SCHEMA: z.string().startsWith("0x"),
 
@@ -167,7 +167,7 @@ export const env = createEnv({
     NEXT_PUBLIC_SKIP_APPROVED_VOTER_CHECK:
       process.env.NEXT_PUBLIC_SKIP_APPROVED_VOTER_CHECK,
 
-    NEXT_PUBLIC_ADMIN_ADDRESSES: process.env.NEXT_PUBLIC_ADMIN_ADDRESSES,
+    NEXT_PUBLIC_ADMIN_ADDRESS: process.env.NEXT_PUBLIC_ADMIN_ADDRESS,
     NEXT_PUBLIC_APPROVAL_SCHEMA: process.env.NEXT_PUBLIC_APPROVAL_SCHEMA,
     NEXT_PUBLIC_METADATA_SCHEMA: process.env.NEXT_PUBLIC_METADATA_SCHEMA,
 

--- a/src/features/distribute/hooks/useAlloPool.ts
+++ b/src/features/distribute/hooks/useAlloPool.ts
@@ -62,7 +62,7 @@ export function useCreatePool() {
         profileId: params.profileId as Address,
         strategy: allo.strategyAddress,
         token: allo.tokenAddress,
-        managers: config.admins,
+        managers: [config.admin],
         amount: params.initialFunding ?? 0n,
         metadata: { protocol: 1n, pointer: "" },
         initStrategyData: "0x",

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -3,5 +3,5 @@ import { config } from "~/config";
 
 export function useIsAdmin() {
   const { address } = useAccount();
-  return config.admins.includes(address!);
+  return config.admin === address!;
 }

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -36,7 +36,7 @@ export const Layout = ({ children, ...props }: Props) => {
     });
   }
 
-  if (config.admins.includes(address!)) {
+  if (config.admin === address!) {
     navLinks.push(
       ...[
         {

--- a/src/server/api/routers/applications.ts
+++ b/src/server/api/routers/applications.ts
@@ -15,7 +15,7 @@ export const applicationsRouter = createTRPCRouter({
     .query(async ({ input }) => {
       return fetchAttestations([eas.schemas.approval], {
         where: {
-          attester: { in: config.admins },
+          attester: { equals: config.admin },
           refUID: input.ids ? { in: input.ids } : undefined,
           AND: [
             createDataFilter("type", "bytes32", "application"),

--- a/src/server/api/routers/projects.ts
+++ b/src/server/api/routers/projects.ts
@@ -21,7 +21,7 @@ export const projectsRouter = createTRPCRouter({
   count: publicProcedure.query(async ({}) => {
     return fetchAttestations([eas.schemas.approval], {
       where: {
-        attester: { in: config.admins },
+        attester: { equals: config.admin },
         AND: [
           createDataFilter("type", "bytes32", "application"),
           createDataFilter("round", "bytes32", config.roundId),
@@ -61,7 +61,7 @@ export const projectsRouter = createTRPCRouter({
 
     return fetchAttestations([eas.schemas.approval], {
       where: {
-        attester: { in: config.admins },
+        attester: { equals: config.admin },
         ...createDataFilter("type", "bytes32", "application"),
       },
     }).then((attestations = []) => {
@@ -120,7 +120,7 @@ export const projectsRouter = createTRPCRouter({
 
     return fetchAttestations([eas.schemas.approval], {
       where: {
-        attester: { in: config.admins },
+        attester: { equals: config.admin },
         ...createDataFilter("type", "bytes32", "application"),
       },
     }).then((attestations = []) => {
@@ -147,7 +147,7 @@ export async function getAllApprovedProjects(): Promise<Attestation[]> {
 
   return fetchAttestations([eas.schemas.approval], {
     where: {
-      attester: { in: config.admins },
+      attester: { equals: config.admin },
       ...createDataFilter("type", "bytes32", "application"),
     },
   }).then((attestations = []) => {

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -127,7 +127,7 @@ const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
 
 const enforceUserIsAdmin = t.middleware(({ ctx, next }) => {
   const address = ctx.session?.user.name;
-  if (!config.admins.includes(address as `0x${string}`)) {
+  if (!(config.admin === (address as `0x${string}`))) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
       message: "Must be admin to access this route",


### PR DESCRIPTION
**Description**
The problem is we only allow single valid attester in our `EASGatekeeper`, but the frontend config actually accepts multiple users as admins.

We could either do:
1. separate `VALID_ATTESTER` from `NEXT_PUBLIC_ADMIN_ADDRESSES`
2. or just limit the admin to only one

This PR takes the 2nd way, so 
- replace all mention of `NEXT_PUBLIC_ADMIN_ADDRESSES` to `NEXT_PUBLIC_ADMIN_ADDRESS`
- since the `config.admins` were `string[]`, while `config.admin` is just a `string`, rewrite query conditions from `in` or `includes` to `equals` or `===`
- update documentations

**Related Issue**
close #119 and #87 