### PR TITLE
fix: add empty array as fallback for impact categories

### DIFF
--- a/src/features/applications/components/ApplicationForm.tsx
+++ b/src/features/applications/components/ApplicationForm.tsx
@@ -42,7 +42,8 @@ const ImpactTags = (): JSX.Element => {
     control,
   });
 
-  const selected = watch("application.impactCategory");
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const selected = watch("application.impactCategory") ?? [];
 
   const error = formState.errors.application?.impactCategory;
   return (


### PR DESCRIPTION
error:

```
TypeError: Cannot read properties of undefined (reading 'includes')
  page: '/applications/new'
```