### PR TITLE
feat: add tooltip

### DIFF
--- a/src/components/ui/Form.tsx
+++ b/src/components/ui/Form.tsx
@@ -25,6 +25,7 @@ import { cn } from "~/utils/classNames";
 
 import { IconButton } from "./Button";
 import { inputBase, Input, InputWrapper, InputIcon } from "./Input";
+import { Tooltip } from "./Tooltip";
 
 import { createComponent } from ".";
 
@@ -104,19 +105,21 @@ export const FormControl = ({
 
   return (
     <fieldset className={cn(className)}>
-      {label && (
-        <Label className="mb-1 dark:text-white" htmlFor={name} required={required}>
-          {label}
-        </Label>
-      )}
+      <div className="flex items-center gap-1">
+        {label && (
+          <Label className="mb-1 dark:text-white" htmlFor={name} required={required}>
+            {label}
+          </Label>
+        )}
+
+        {hint && <Tooltip description={hint} />}
+      </div>
 
       {cloneElement(children as ReactElement, {
         id: name,
         error: Boolean(error),
         ...register(name, { valueAsNumber }),
       })}
-
-      {hint && <div className="pt-1 text-xs text-gray-500">{hint}</div>}
 
       {error && <ErrorMessage>{error.message}</ErrorMessage>}
     </fieldset>

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,30 @@
+import { useState, useCallback } from "react";
+import { CiCircleQuestion } from "react-icons/ci";
+
+interface ITooltipProps {
+  description: string;
+}
+
+export const Tooltip = ({ description }: ITooltipProps): JSX.Element => {
+  const [showBlock, setShowBlock] = useState<boolean>(false);
+
+  const handleShowBlock = useCallback(() => {
+    setShowBlock(true);
+  }, [setShowBlock]);
+
+  const handleHideBlock = useCallback(() => {
+    setShowBlock(false);
+  }, [setShowBlock]);
+
+  return (
+    <div className="relative cursor-pointer text-gray-500 dark:text-white">
+      <CiCircleQuestion onMouseEnter={handleShowBlock} onMouseLeave={handleHideBlock} />
+
+      {showBlock && (
+        <div className="t-0 l-l absolute min-w-60 rounded-md bg-white p-3 text-gray-500 shadow-md dark:bg-lightBlack">
+          {description}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/applications/components/ApplicationForm.tsx
+++ b/src/features/applications/components/ApplicationForm.tsx
@@ -82,7 +82,7 @@ export const ApplicationForm = (): JSX.Element => {
           description="Please provide information about your project."
           title="Project Profile"
         >
-          <FormControl required label="Project name" name="name">
+          <FormControl required hint="This is the name of your project" label="Project name" name="name">
             <Input placeholder="Type your project name" />
           </FormControl>
 
@@ -105,7 +105,13 @@ export const ApplicationForm = (): JSX.Element => {
               <Input placeholder="Type your twitter username" />
             </FormControl>
 
-            <FormControl className="flex-1" label="Github" name="github" required={false}>
+            <FormControl
+              className="flex-1"
+              hint="Provide your github of this project"
+              label="Github"
+              name="github"
+              required={false}
+            >
               <Input placeholder="Type your github username" />
             </FormControl>
           </div>


### PR DESCRIPTION
**Description**
There's no description of what each field is, there's a `hint` param but never used, and it's adding lines under the input field, not sure if it's a good UI for displaying long description, also might need this `Tooltip` widget elsewhere in the whole maci-rpgf project, so made one in the `components/ui`.

Not adding much description about the form fields yet, since I'm not sure how to explain them. Just added two for demo how it looks like.

**Related Issues**
close #212 