### PR TITLE
fix: 0 being displayed on the projectItem

### DIFF
--- a/src/features/projects/components/ProjectItem.tsx
+++ b/src/features/projects/components/ProjectItem.tsx
@@ -58,7 +58,7 @@ export const ProjectItem = ({
           <ImpactCategories tags={metadata.data?.impactCategory} />
         </Skeleton>
 
-        {!isLoading && state && action && appState === EAppState.VOTING && (
+        {!isLoading && state !== undefined && action && appState === EAppState.VOTING && (
           <div className="flex justify-end pt-6">
             <Skeleton>
               {state === EProjectState.DEFAULT && (


### PR DESCRIPTION
**Description**
just a small bug, that if there's not any state should be displayed on the buttons section on the `ProjectItem`, a `0` would be displayed, this should be removed.